### PR TITLE
Customize implicit binding validation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,21 @@ GET /posts-by-slug/bar => 404
 
 See [https://laravel.com/docs/routing#implicit-binding](https://laravel.com/docs/routing#implicit-binding)
 
-### Bindings explicites
+#### Customize implicit route binding error
+
+You can customize the way this package will handle validation failure for implicit bindings.
+
+In a Service provider, just call `InvalidRouteBinding::handleUsing` :
+
+```php
+InvalidRouteBinding::handleUsing(function (string $class, string $field): never {
+    Log::error("Invalid binding for $class on $field.");
+
+    abort(422);
+});
+```
+
+### Explicit bindings
 
 You can explicitly bind your models using `\Soyhuce\ModelInjection\BindModels` trait in a service
 provider (`RouteServiceProvider` for exemple).

--- a/src/InvalidRouteBinding.php
+++ b/src/InvalidRouteBinding.php
@@ -1,4 +1,4 @@
-<?php
+<?php declare(strict_types=1);
 
 namespace Soyhuce\ModelInjection;
 
@@ -11,7 +11,7 @@ class InvalidRouteBinding
     public static ?Closure $handler = null;
 
     /**
-     * @param ?\Closure(string, string): mixed $handler
+     * @param ?Closure(string, string): mixed $handler
      */
     public static function handleUsing(?Closure $handler): void
     {
@@ -20,8 +20,8 @@ class InvalidRouteBinding
 
     public static function handle(string $model, string $field): void
     {
-        static::$handler ??= function () {
-            throw new ModelNotFoundException("Invalid route binding.");
+        static::$handler ??= function (): void {
+            throw new ModelNotFoundException('Invalid route binding.');
         };
 
         (static::$handler)($model, $field);

--- a/src/InvalidRouteBinding.php
+++ b/src/InvalidRouteBinding.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Soyhuce\ModelInjection;
+
+use Closure;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class InvalidRouteBinding
+{
+    /** @var ?Closure(string, string) */
+    public static ?Closure $handler = null;
+
+    /**
+     * @param ?\Closure(string, string): mixed $handler
+     */
+    public static function handleUsing(?Closure $handler): void
+    {
+        static::$handler = $handler;
+    }
+
+    public static function handle(string $model, string $field): void
+    {
+        static::$handler ??= function () {
+            throw new ModelNotFoundException("Invalid route binding.");
+        };
+
+        (static::$handler)($model, $field);
+    }
+}

--- a/src/ValidatesImplicitBinding.php
+++ b/src/ValidatesImplicitBinding.php
@@ -4,7 +4,6 @@ namespace Soyhuce\ModelInjection;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Str;
 use function in_array;
 
 /**
@@ -12,14 +11,6 @@ use function in_array;
  */
 trait ValidatesImplicitBinding
 {
-    /**
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param mixed $value
-     * @param string|null $field
-     * @return \Illuminate\Database\Eloquent\Builder
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     */
     public function resolveRouteBindingQuery($query, $value, $field = null)
     {
         $this->validateRouteBinding($value, $field);
@@ -27,14 +18,6 @@ trait ValidatesImplicitBinding
         return parent::resolveRouteBindingQuery($query, $value, $field);
     }
 
-    /**
-     * @param string $childType
-     * @param mixed $value
-     * @param string|null $field
-     * @return \Illuminate\Database\Eloquent\Builder
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-     * @phpcsSuppress SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint
-     */
     protected function resolveChildRouteBindingQuery($childType, $value, $field)
     {
         $this->validateChildRouteBinding($childType, $value, $field);
@@ -51,9 +34,9 @@ trait ValidatesImplicitBinding
         }
     }
 
-    public function validateChildRouteBinding(string $childType, mixed $value, string $field): void
+    public function validateChildRouteBinding(string $childType, mixed $value, ?string $field): void
     {
-        $related = $this->{Str::plural(Str::camel($childType))}()->getRelated();
+        $related = $this->{$this->childRouteBindingRelationshipName($childType)}()->getRelated();
 
         if (in_array(ValidatesImplicitBinding::class, class_uses_recursive($related))) {
             $related->validateRouteBinding($value, $field ?: $related->getRouteKey());

--- a/src/ValidatesImplicitBinding.php
+++ b/src/ValidatesImplicitBinding.php
@@ -2,7 +2,6 @@
 
 namespace Soyhuce\ModelInjection;
 
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Facades\Validator;
 use function in_array;
 
@@ -30,7 +29,7 @@ trait ValidatesImplicitBinding
         $field ??= $this->getRouteKeyName();
 
         if (Validator::make([$field => $value], [$field => $this->routeBindingRule($field)])->fails()) {
-            throw new ModelNotFoundException('The model key is invalid.');
+            InvalidRouteBinding::handle(static::class, $field);
         }
     }
 

--- a/src/ValidatesImplicitBinding.php
+++ b/src/ValidatesImplicitBinding.php
@@ -3,6 +3,7 @@
 namespace Soyhuce\ModelInjection;
 
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
 use function in_array;
 
 /**
@@ -35,7 +36,7 @@ trait ValidatesImplicitBinding
 
     public function validateChildRouteBinding(string $childType, mixed $value, ?string $field): void
     {
-        $related = $this->{$this->childRouteBindingRelationshipName($childType)}()->getRelated();
+        $related = $this->{Str::plural(Str::camel($childType))}()->getRelated();
 
         if (in_array(ValidatesImplicitBinding::class, class_uses_recursive($related))) {
             $related->validateRouteBinding($value, $field ?: $related->getRouteKey());

--- a/tests/ValidateImplicitBindingTest.php
+++ b/tests/ValidateImplicitBindingTest.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-use Illuminate\Support\Facades\Log as Log;
+use Illuminate\Support\Facades\Log;
 use Soyhuce\ModelInjection\InvalidRouteBinding;
 use Soyhuce\ModelInjection\RouteBindingValidationMustBeDefined;
 use Soyhuce\ModelInjection\Tests\Fixtures\Post;
@@ -219,14 +219,14 @@ it('fails when custom key does not have validation rule for scoped model', funct
 
 it('allows to customize invalid binding handling', function (): void {
     InvalidRouteBinding::handleUsing(function (string $class, string $field): never {
-        Log::error("Invalid binding for $class on $field.");
+        Log::error("Invalid binding for {$class} on {$field}.");
 
         abort(422);
     });
 
     Log::spy()
         ->shouldReceive('error')
-        ->with("Invalid binding for Soyhuce\ModelInjection\Tests\Fixtures\User on id.")
+        ->with('Invalid binding for Soyhuce\\ModelInjection\\Tests\\Fixtures\\User on id.')
         ->once();
 
     $this->getJson('users/foo')


### PR DESCRIPTION
This PR allows to customize the way validation failures are handled on implicit bindings 

```php
InvalidRouteBinding::handleUsing(function (string $class, string $field): never {
    Log::error("Invalid binding for $class on $field.");

    abort(422);
});
```

closes #13 